### PR TITLE
resolve #2 alert以下のログ出力メソッドを実装

### DIFF
--- a/src/LambdaLogger.ts
+++ b/src/LambdaLogger.ts
@@ -50,38 +50,116 @@ export class LambdaLogger {
   /**
    * 2 Critical (RFC5424)
    * critical conditions
+   *
+   * @param value
+   * @returns {LambdaLogOutput}
    */
-  static critical() {}
+  static critical(value: any): LambdaLogOutput {
+    const logLevel = "CRITICAL";
+    const contents = LambdaLogger.createLogContents(logLevel, value);
+
+    LambdaLogger.log(contents);
+
+    return {
+      logLevel,
+      contents
+    };
+  }
 
   /**
    * 3 Error (RFC5424)
    * error conditions
+   *
+   * @param value
+   * @returns {LambdaLogOutput}
    */
-  static error() {}
+  static error(value: any): LambdaLogOutput {
+    const logLevel = "ERROR";
+    const contents = LambdaLogger.createLogContents(logLevel, value);
+
+    LambdaLogger.log(contents);
+
+    return {
+      logLevel,
+      contents
+    };
+  }
 
   /**
    * 4 Warning (RFC5424)
    * warning conditions
+   *
+   * @param value
+   * @returns {LambdaLogOutput}
    */
-  static warning() {}
+  static warning(value: any): LambdaLogOutput {
+    const logLevel = "WARNING";
+    const contents = LambdaLogger.createLogContents(logLevel, value);
+
+    LambdaLogger.log(contents);
+
+    return {
+      logLevel,
+      contents
+    };
+  }
 
   /**
    * 5 Notice (RFC5424)
    * normal but significant condition
+   *
+   * @param value
+   * @returns {LambdaLogOutput}
    */
-  static notice() {}
+  static notice(value: any): LambdaLogOutput {
+    const logLevel = "NOTICE";
+    const contents = LambdaLogger.createLogContents(logLevel, value);
+
+    LambdaLogger.log(contents);
+
+    return {
+      logLevel,
+      contents
+    };
+  }
 
   /**
    * 6 Informational (RFC5424)
    * informational messages
+   *
+   * @param value
+   * @returns {LambdaLogOutput}
    */
-  static informational() {}
+  static informational(value: any): LambdaLogOutput {
+    const logLevel = "INFORMATIONAL";
+    const contents = LambdaLogger.createLogContents(logLevel, value);
+
+    LambdaLogger.log(contents);
+
+    return {
+      logLevel,
+      contents
+    };
+  }
 
   /**
    * 7 Debug (RFC5424)
    * debug-level messages
+   *
+   * @param value
+   * @returns {LambdaLogOutput}
    */
-  static debug() {}
+  static debug(value: any): LambdaLogOutput {
+    const logLevel = "DEBUG";
+    const contents = LambdaLogger.createLogContents(logLevel, value);
+
+    LambdaLogger.log(contents);
+
+    return {
+      logLevel,
+      contents
+    };
+  }
 
   /**
    * @param {string} contents

--- a/src/LambdaLogger.ts
+++ b/src/LambdaLogger.ts
@@ -31,8 +31,21 @@ export class LambdaLogger {
   /**
    * 1 Alert (RFC5424)
    * action must be taken immediately
+   *
+   * @param value
+   * @returns {LambdaLogOutput}
    */
-  static alert() {}
+  static alert(value: any): LambdaLogOutput {
+    const logLevel = "ALERT";
+    const contents = LambdaLogger.createLogContents(logLevel, value);
+
+    LambdaLogger.log(contents);
+
+    return {
+      logLevel,
+      contents
+    };
+  }
 
   /**
    * 2 Critical (RFC5424)

--- a/test/LambdaLogger.spec.ts
+++ b/test/LambdaLogger.spec.ts
@@ -38,4 +38,78 @@ describe("LambdaLogger", () => {
     expect(logOutput.logLevel).toBe("ALERT");
     expect(logOutput.contents).toBe(expectedContents);
   });
+
+  it("should be able to output Critical logs", () => {
+    const message = "hello";
+
+    const logOutput = LambdaLogger.critical(message);
+
+    const expectedContents = `CRITICAL \n ${util.inspect(
+      message,
+      false,
+      null
+    )}`;
+
+    expect(logOutput.logLevel).toBe("CRITICAL");
+    expect(logOutput.contents).toBe(expectedContents);
+  });
+
+  it("should be able to output Error logs", () => {
+    const message = "hello";
+
+    const logOutput = LambdaLogger.error(message);
+
+    const expectedContents = `ERROR \n ${util.inspect(message, false, null)}`;
+
+    expect(logOutput.logLevel).toBe("ERROR");
+    expect(logOutput.contents).toBe(expectedContents);
+  });
+
+  it("should be able to output Warning logs", () => {
+    const message = "hello";
+
+    const logOutput = LambdaLogger.warning(message);
+
+    const expectedContents = `WARNING \n ${util.inspect(message, false, null)}`;
+
+    expect(logOutput.logLevel).toBe("WARNING");
+    expect(logOutput.contents).toBe(expectedContents);
+  });
+
+  it("should be able to output Notice logs", () => {
+    const message = "hello";
+
+    const logOutput = LambdaLogger.notice(message);
+
+    const expectedContents = `NOTICE \n ${util.inspect(message, false, null)}`;
+
+    expect(logOutput.logLevel).toBe("NOTICE");
+    expect(logOutput.contents).toBe(expectedContents);
+  });
+
+  it("should be able to output Informational logs", () => {
+    const message = "hello";
+
+    const logOutput = LambdaLogger.informational(message);
+
+    const expectedContents = `INFORMATIONAL \n ${util.inspect(
+      message,
+      false,
+      null
+    )}`;
+
+    expect(logOutput.logLevel).toBe("INFORMATIONAL");
+    expect(logOutput.contents).toBe(expectedContents);
+  });
+
+  it("should be able to output Debug logs", () => {
+    const messages = ["hello", "world"];
+
+    const logOutput = LambdaLogger.debug(messages);
+
+    const expectedContents = `DEBUG \n ${util.inspect(messages, false, null)}`;
+
+    expect(logOutput.logLevel).toBe("DEBUG");
+    expect(logOutput.contents).toBe(expectedContents);
+  });
 });

--- a/test/LambdaLogger.spec.ts
+++ b/test/LambdaLogger.spec.ts
@@ -27,4 +27,15 @@ describe("LambdaLogger", () => {
     expect(logOutput.logLevel).toBe("EMERGENCY");
     expect(logOutput.contents).toBe(expectedContents);
   });
+
+  it("should be able to output Alert logs", () => {
+    const message = "hello";
+
+    const logOutput = LambdaLogger.alert(message);
+
+    const expectedContents = `ALERT \n ${util.inspect(message, false, null)}`;
+
+    expect(logOutput.logLevel).toBe("ALERT");
+    expect(logOutput.contents).toBe(expectedContents);
+  });
 });


### PR DESCRIPTION
# issueURL
https://github.com/nekonomokochan/aws-lambda-node-logger/issues/2

# やった事
RFC5424で定義されているログ出力メソッドを全て実装
