### PR TITLE
resolve #13 LambdaLogOutputのキー名をcontextに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ REPORT RequestId: 1e46b449-6571-11e8-8af3-e7d42a6dbde1	Duration: 0.94 ms	Billed 
 ```javascript
 'use strict';
 
-const awsLambdaNodeLogger = require("@nekonomokochan/aws-lambda-node-logger");
+const awsLambdaNodeLogger = require('@nekonomokochan/aws-lambda-node-logger');
 
 module.exports.jsTest = (event, context, callback) => {
   const response = {
@@ -82,7 +82,7 @@ module.exports.jsTest = (event, context, callback) => {
     }),
   };
 
-  const error = new Error("JavaScript Error Test");
+  const error = new Error('JavaScript Error Test');
 
   awsLambdaNodeLogger.LambdaLogger.debug(response);
   awsLambdaNodeLogger.LambdaLogger.error(error);

--- a/src/LambdaLogOutput.ts
+++ b/src/LambdaLogOutput.ts
@@ -3,5 +3,5 @@
  */
 export interface LambdaLogOutput {
   logLevel: string;
-  contents: string;
+  context: string;
 }

--- a/src/LambdaLogger.ts
+++ b/src/LambdaLogger.ts
@@ -18,13 +18,13 @@ export class LambdaLogger {
    */
   static emergency(value: any): LambdaLogOutput {
     const logLevel = "EMERGENCY";
-    const contents = LambdaLogger.createContext(logLevel, value);
+    const context = LambdaLogger.createContext(logLevel, value);
 
-    LambdaLogger.log(contents);
+    LambdaLogger.log(context);
 
     return {
       logLevel,
-      contents
+      context
     };
   }
 
@@ -37,13 +37,13 @@ export class LambdaLogger {
    */
   static alert(value: any): LambdaLogOutput {
     const logLevel = "ALERT";
-    const contents = LambdaLogger.createContext(logLevel, value);
+    const context = LambdaLogger.createContext(logLevel, value);
 
-    LambdaLogger.log(contents);
+    LambdaLogger.log(context);
 
     return {
       logLevel,
-      contents
+      context
     };
   }
 
@@ -56,13 +56,13 @@ export class LambdaLogger {
    */
   static critical(value: any): LambdaLogOutput {
     const logLevel = "CRITICAL";
-    const contents = LambdaLogger.createContext(logLevel, value);
+    const context = LambdaLogger.createContext(logLevel, value);
 
-    LambdaLogger.log(contents);
+    LambdaLogger.log(context);
 
     return {
       logLevel,
-      contents
+      context
     };
   }
 
@@ -75,13 +75,13 @@ export class LambdaLogger {
    */
   static error(value: any): LambdaLogOutput {
     const logLevel = "ERROR";
-    const contents = LambdaLogger.createContext(logLevel, value);
+    const context = LambdaLogger.createContext(logLevel, value);
 
-    LambdaLogger.log(contents);
+    LambdaLogger.log(context);
 
     return {
       logLevel,
-      contents
+      context
     };
   }
 
@@ -94,13 +94,13 @@ export class LambdaLogger {
    */
   static warning(value: any): LambdaLogOutput {
     const logLevel = "WARNING";
-    const contents = LambdaLogger.createContext(logLevel, value);
+    const context = LambdaLogger.createContext(logLevel, value);
 
-    LambdaLogger.log(contents);
+    LambdaLogger.log(context);
 
     return {
       logLevel,
-      contents
+      context
     };
   }
 
@@ -113,13 +113,13 @@ export class LambdaLogger {
    */
   static notice(value: any): LambdaLogOutput {
     const logLevel = "NOTICE";
-    const contents = LambdaLogger.createContext(logLevel, value);
+    const context = LambdaLogger.createContext(logLevel, value);
 
-    LambdaLogger.log(contents);
+    LambdaLogger.log(context);
 
     return {
       logLevel,
-      contents
+      context
     };
   }
 
@@ -132,13 +132,13 @@ export class LambdaLogger {
    */
   static informational(value: any): LambdaLogOutput {
     const logLevel = "INFORMATIONAL";
-    const contents = LambdaLogger.createContext(logLevel, value);
+    const context = LambdaLogger.createContext(logLevel, value);
 
-    LambdaLogger.log(contents);
+    LambdaLogger.log(context);
 
     return {
       logLevel,
-      contents
+      context
     };
   }
 
@@ -151,21 +151,21 @@ export class LambdaLogger {
    */
   static debug(value: any): LambdaLogOutput {
     const logLevel = "DEBUG";
-    const contents = LambdaLogger.createContext(logLevel, value);
+    const context = LambdaLogger.createContext(logLevel, value);
 
-    LambdaLogger.log(contents);
+    LambdaLogger.log(context);
 
     return {
       logLevel,
-      contents
+      context
     };
   }
 
   /**
-   * @param {string} contents
+   * @param {string} context
    */
-  private static log(contents: string) {
-    console.log(contents);
+  private static log(context: string) {
+    console.log(context);
   }
 
   /**

--- a/src/LambdaLogger.ts
+++ b/src/LambdaLogger.ts
@@ -18,7 +18,7 @@ export class LambdaLogger {
    */
   static emergency(value: any): LambdaLogOutput {
     const logLevel = "EMERGENCY";
-    const contents = LambdaLogger.createLogContents(logLevel, value);
+    const contents = LambdaLogger.createContext(logLevel, value);
 
     LambdaLogger.log(contents);
 
@@ -37,7 +37,7 @@ export class LambdaLogger {
    */
   static alert(value: any): LambdaLogOutput {
     const logLevel = "ALERT";
-    const contents = LambdaLogger.createLogContents(logLevel, value);
+    const contents = LambdaLogger.createContext(logLevel, value);
 
     LambdaLogger.log(contents);
 
@@ -56,7 +56,7 @@ export class LambdaLogger {
    */
   static critical(value: any): LambdaLogOutput {
     const logLevel = "CRITICAL";
-    const contents = LambdaLogger.createLogContents(logLevel, value);
+    const contents = LambdaLogger.createContext(logLevel, value);
 
     LambdaLogger.log(contents);
 
@@ -75,7 +75,7 @@ export class LambdaLogger {
    */
   static error(value: any): LambdaLogOutput {
     const logLevel = "ERROR";
-    const contents = LambdaLogger.createLogContents(logLevel, value);
+    const contents = LambdaLogger.createContext(logLevel, value);
 
     LambdaLogger.log(contents);
 
@@ -94,7 +94,7 @@ export class LambdaLogger {
    */
   static warning(value: any): LambdaLogOutput {
     const logLevel = "WARNING";
-    const contents = LambdaLogger.createLogContents(logLevel, value);
+    const contents = LambdaLogger.createContext(logLevel, value);
 
     LambdaLogger.log(contents);
 
@@ -113,7 +113,7 @@ export class LambdaLogger {
    */
   static notice(value: any): LambdaLogOutput {
     const logLevel = "NOTICE";
-    const contents = LambdaLogger.createLogContents(logLevel, value);
+    const contents = LambdaLogger.createContext(logLevel, value);
 
     LambdaLogger.log(contents);
 
@@ -132,7 +132,7 @@ export class LambdaLogger {
    */
   static informational(value: any): LambdaLogOutput {
     const logLevel = "INFORMATIONAL";
-    const contents = LambdaLogger.createLogContents(logLevel, value);
+    const contents = LambdaLogger.createContext(logLevel, value);
 
     LambdaLogger.log(contents);
 
@@ -151,7 +151,7 @@ export class LambdaLogger {
    */
   static debug(value: any): LambdaLogOutput {
     const logLevel = "DEBUG";
-    const contents = LambdaLogger.createLogContents(logLevel, value);
+    const contents = LambdaLogger.createContext(logLevel, value);
 
     LambdaLogger.log(contents);
 
@@ -173,7 +173,7 @@ export class LambdaLogger {
    * @param value
    * @returns {string}
    */
-  private static createLogContents(logLevel: string, value: any): string {
+  private static createContext(logLevel: string, value: any): string {
     return `${logLevel} \n ${util.inspect(value, false, null)}`;
   }
 }

--- a/test/LambdaLogger.spec.ts
+++ b/test/LambdaLogger.spec.ts
@@ -22,10 +22,10 @@ describe("LambdaLogger", () => {
 
     const logOutput = LambdaLogger.emergency(error);
 
-    const expectedContents = `EMERGENCY \n ${util.inspect(error, false, null)}`;
+    const expectedContext = `EMERGENCY \n ${util.inspect(error, false, null)}`;
 
     expect(logOutput.logLevel).toBe("EMERGENCY");
-    expect(logOutput.contents).toBe(expectedContents);
+    expect(logOutput.context).toBe(expectedContext);
   });
 
   it("should be able to output Alert logs", () => {
@@ -33,10 +33,10 @@ describe("LambdaLogger", () => {
 
     const logOutput = LambdaLogger.alert(message);
 
-    const expectedContents = `ALERT \n ${util.inspect(message, false, null)}`;
+    const expectedContext = `ALERT \n ${util.inspect(message, false, null)}`;
 
     expect(logOutput.logLevel).toBe("ALERT");
-    expect(logOutput.contents).toBe(expectedContents);
+    expect(logOutput.context).toBe(expectedContext);
   });
 
   it("should be able to output Critical logs", () => {
@@ -44,14 +44,10 @@ describe("LambdaLogger", () => {
 
     const logOutput = LambdaLogger.critical(message);
 
-    const expectedContents = `CRITICAL \n ${util.inspect(
-      message,
-      false,
-      null
-    )}`;
+    const expectedContext = `CRITICAL \n ${util.inspect(message, false, null)}`;
 
     expect(logOutput.logLevel).toBe("CRITICAL");
-    expect(logOutput.contents).toBe(expectedContents);
+    expect(logOutput.context).toBe(expectedContext);
   });
 
   it("should be able to output Error logs", () => {
@@ -59,10 +55,10 @@ describe("LambdaLogger", () => {
 
     const logOutput = LambdaLogger.error(message);
 
-    const expectedContents = `ERROR \n ${util.inspect(message, false, null)}`;
+    const expectedContext = `ERROR \n ${util.inspect(message, false, null)}`;
 
     expect(logOutput.logLevel).toBe("ERROR");
-    expect(logOutput.contents).toBe(expectedContents);
+    expect(logOutput.context).toBe(expectedContext);
   });
 
   it("should be able to output Warning logs", () => {
@@ -70,10 +66,10 @@ describe("LambdaLogger", () => {
 
     const logOutput = LambdaLogger.warning(message);
 
-    const expectedContents = `WARNING \n ${util.inspect(message, false, null)}`;
+    const expectedContext = `WARNING \n ${util.inspect(message, false, null)}`;
 
     expect(logOutput.logLevel).toBe("WARNING");
-    expect(logOutput.contents).toBe(expectedContents);
+    expect(logOutput.context).toBe(expectedContext);
   });
 
   it("should be able to output Notice logs", () => {
@@ -81,10 +77,10 @@ describe("LambdaLogger", () => {
 
     const logOutput = LambdaLogger.notice(message);
 
-    const expectedContents = `NOTICE \n ${util.inspect(message, false, null)}`;
+    const expectedContext = `NOTICE \n ${util.inspect(message, false, null)}`;
 
     expect(logOutput.logLevel).toBe("NOTICE");
-    expect(logOutput.contents).toBe(expectedContents);
+    expect(logOutput.context).toBe(expectedContext);
   });
 
   it("should be able to output Informational logs", () => {
@@ -92,14 +88,14 @@ describe("LambdaLogger", () => {
 
     const logOutput = LambdaLogger.informational(message);
 
-    const expectedContents = `INFORMATIONAL \n ${util.inspect(
+    const expectedContext = `INFORMATIONAL \n ${util.inspect(
       message,
       false,
       null
     )}`;
 
     expect(logOutput.logLevel).toBe("INFORMATIONAL");
-    expect(logOutput.contents).toBe(expectedContents);
+    expect(logOutput.context).toBe(expectedContext);
   });
 
   it("should be able to output Debug logs", () => {
@@ -107,9 +103,9 @@ describe("LambdaLogger", () => {
 
     const logOutput = LambdaLogger.debug(messages);
 
-    const expectedContents = `DEBUG \n ${util.inspect(messages, false, null)}`;
+    const expectedContext = `DEBUG \n ${util.inspect(messages, false, null)}`;
 
     expect(logOutput.logLevel).toBe("DEBUG");
-    expect(logOutput.contents).toBe(expectedContents);
+    expect(logOutput.context).toBe(expectedContext);
   });
 });


### PR DESCRIPTION
# issueURL
https://github.com/nekonomokochan/aws-lambda-node-logger/issues/13

# やった事
表題の通り。

ついでにcontentsという名称を全般的にcontextに変更。

内部的に利用していた名前なので本件はライブラリの利用者には影響なし。