### PR TITLE
resolve #12 Travis CIでテストを実行する設定を追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - node
+dist: trusty
+sudo: false
+cache: yarn
+script: yarn run test:coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # aws-lambda-node-logger
 
 [![npm version](https://badge.fury.io/js/%40nekonomokochan%2Faws-lambda-node-logger.svg)](https://badge.fury.io/js/%40nekonomokochan%2Faws-lambda-node-logger)
+[![Build Status](https://travis-ci.org/nekonomokochan/aws-lambda-node-logger.svg?branch=master)](https://travis-ci.org/nekonomokochan/aws-lambda-node-logger)
+[![Coverage Status](https://coveralls.io/repos/github/nekonomokochan/aws-lambda-node-logger/badge.svg)](https://coveralls.io/github/nekonomokochan/aws-lambda-node-logger)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Logging library for AWS Lambda

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@types/jest": "^23.0.0",
     "@types/node": "^10.3.0",
+    "coveralls": "^3.0.1",
     "jest": "^23.1.0",
     "prettier": "^1.13.4",
     "ts-jest": "^22.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -662,6 +662,16 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+coveralls@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.1.tgz#12e15914eaa29204e56869a5ece7b9e1492d2ae2"
+  dependencies:
+    js-yaml "^3.6.1"
+    lcov-parse "^0.0.10"
+    log-driver "^1.2.5"
+    minimist "^1.2.0"
+    request "^2.79.0"
+
 cpx@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/cpx/-/cpx-1.5.0.tgz#185be018511d87270dedccc293171e37655ab88f"
@@ -2041,7 +2051,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.7.0:
+js-yaml@^3.6.1, js-yaml@^3.7.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -2152,6 +2162,10 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+lcov-parse@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
+
 left-pad@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
@@ -2191,6 +2205,10 @@ lodash.sortby@^4.7.0:
 lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
+log-driver@^1.2.5:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -2820,7 +2838,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.83.0:
+request@^2.79.0, request@^2.83.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:


### PR DESCRIPTION
# issueURL
https://github.com/nekonomokochan/aws-lambda-node-logger/issues/12

# やった事
- Travis CIで継続的インテグレーションの設定
- Coverallsでカバレッジが出力されるように設定
- READMEにTravis CIとCoverallsのバッジを追加
- リポジトリの設定を変更（テスト失敗時はマージ出来ないように設定変更）